### PR TITLE
The goal of this commit is to ensure that the user is able to **get**…

### DIFF
--- a/account/form.py
+++ b/account/form.py
@@ -9,11 +9,11 @@ class ProfileForm(forms.ModelForm):
         model  =  Profile
         fields =  "__all__"
         widgets = {
-            "first_name": forms.TextInput(attrs={"id": "first-name", "minlength": "3", "maxlength": "40", "required": "required", "class": "center"}),
+            "first_name": forms.TextInput(attrs={"id": "first-name", "minlength": "3",  "maxlength": "40", "required": "required", "class": "center"}),
             "surname": forms.TextInput(attrs={"id": "surname", "minlength": "3", "maxlength": "40", "class": "center"}),
             "mobile": forms.TextInput(attrs={"type": "tel", "id": "mobile", "maxlength": "11", "minlength": "11", "class": "center"}),
             "country": forms.TextInput(attrs={"id": "country", "minlength": "4", "maxlength": "50", "class": "center"}),
-            "state": forms.TextInput(attrs={"id": "state", "maxlength": "11", "minlength": "11", "class": "center"}),
+            "state": forms.TextInput(attrs={"id": "state", "maxlength": "11", "minlength": "3", "class": "center"}),
             "postcode": forms.TextInput(attrs={"id": "postcode", "minlength": "5", "maxlength": "5", "class": "center"})
         }
 

--- a/account/models.py
+++ b/account/models.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from django.db import models
 from django.core.validators import MinValueValidator
 
@@ -131,6 +132,17 @@ class Profile(models.Model):
     signature                = models.CharField(choices=Signature.choices, max_length=1)
     created_on              = models.DateTimeField(auto_now_add=True)
     modified_on             = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        if self.first_name and self.surname:
+         return f"{self.first_name.title()}{self.surname.title()}"
+    
+    @classmethod
+    def get_by_user(cls, user: User) -> Optional[User]:
+        try:
+            return cls.objects.get(user=user)
+        except cls.DoesNotExist:
+            return None
 
     def save(self, *args, **kwargs):
         if not self.email:

--- a/account/urls.py
+++ b/account/urls.py
@@ -4,6 +4,8 @@ from . import views
 
 urlpatterns = [
     path('save/', view=views.save_profile_details, name="save_profile_details" ),
+    path('update/', view=views.update_profile_details, name="update_profile_details"),
+    path('get/', view=views.get_profile_details, name="get_profile_data")
     
  
 ]

--- a/account/utils/errors.py
+++ b/account/utils/errors.py
@@ -1,0 +1,88 @@
+"""
+Custom exceptions for user profile management.
+
+This module defines a hierarchy of custom exceptions used throughout the user profile
+handling system. All custom exceptions inherit from `CustomBaseError`, which provides a
+consistent interface and message formatting across the application.
+
+Classes:
+    - CustomBaseError: The base class for all custom exceptions.
+    - ProfileAlreadyExistsError: Raised when attempting to create a profile that already exists.
+    - UserDoesNotExistError: Raised when operations are performed on a non-existent user.
+
+Usage:
+    These exceptions are intended to improve error handling clarity and provide more
+    specific context when raising and catching errors in views, services, or forms.
+
+Example:
+    raise ProfileAlreadyExistsError()
+
+    try:
+        profile = Profile.get_by_user(user)
+    except UserDoesNotExistError:
+        handle_missing_user()
+
+
+
+"""
+
+
+
+class CustomBaseError(Exception):
+    """
+    Base class for custom application-specific exceptions.
+
+    This class extends Python's built-in `Exception` class and provides a standard
+    structure for all custom exceptions used in the application. It allows for a
+    default message to be provided, and overrides the `__str__` method to return
+    the message directly.
+
+    Attributes:
+        message (str): A human-readable error message. Defaults to "An error occurred."
+    """
+    def __init__(self, message=None):
+        if message is None:
+            message = "An error occurred."
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+
+
+class ProfileAlreadyExistsError(CustomBaseError):
+    """
+    Raised when attempting to create a profile for a user who already has one.
+
+    This exception is typically used to prevent duplicate profile creation,
+    and to make sure that each user is associated with only one profile.
+
+    Inherits from:
+        CustomBaseError
+
+    Default message:
+        "A profile for this user already exists"
+    """
+    def __init__(self, message="A profile for this user already exists"):
+        super().__init__(message)
+
+
+
+class UserDoesNotExistError(CustomBaseError):
+    """
+    Raised when attempting to retrieve a user that does not exist.
+
+    This exception is commonly used when retrieving or updating user-related data
+    for a user that cannot be found in the system.
+
+    Inherits from:
+        CustomBaseError
+
+    Default message:
+        "The user doesn't exist"
+    """
+    def __init__(self, message="The user doesn't exist"):
+        super().__init__(message)
+

--- a/account/views.py
+++ b/account/views.py
@@ -1,57 +1,179 @@
-import json
 
-from django.db import IntegrityError
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_protect
 from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest
 
-
-from .views_helper import api_response, profile_to_dict
+from .utils.errors import ProfileAlreadyExistsError, UserDoesNotExistError
+from .views_helper import (profile_to_dict, 
+                           handle_profile_json,
+                           update_changed_profile_fields, 
+                            
+                             api_response)
 from .models import Profile
+
 
 
 @csrf_protect
 @login_required
 def save_profile_details(request):
- 
-    if request.method != "POST":
-        return api_response(error="Only POST method is allowed", status_code=405)
-  
-    user = request.user
-    if Profile.objects.filter(user=user).exists():
-        return api_response(error="Profile for this user already exists", status_code=409)
-    
-    try:
-        data = json.loads(request.body.decode('utf-8'))
-    except json.JSONDecodeError as e:
-        error_msg = f'Invalid JSON data: {str(e)}'
-        return api_response(error=error_msg, status_code=400)
-    
-    try:
-        # Handle Profile
+    """
+    Handle a POST request from the frontend to save user profile details.
+
+    This view is intended to be called via JavaScript (e.g. `fetch`) and delegates
+    the creation of the profile to a helper function. Since the data is being sent
+    as a POST It ensures that the request is authenticated and protected against 
+    CSRF attacks.
+
+    The actual logic for creating the profile is handled by the `create_profile` 
+    closure, and serialisation is performed using `profile_to_dict`.
+
+    Only users who do not already have a profile may create one. Each user can 
+    only have one profile, if an Attempt to create a profile where one exists 
+    a `ProfileAlreadyExistsError` will be raised.
+
+    Returns:
+        JsonResponse: A JSON response containing the saved profile data or an error.
+    """
+
+    def create_profile(data: dict, request: HttpRequest):
+        """
+        Create a new user profile if one does not already exist.
+
+        Called by `handle_profile_json`, this function receives a dictionary
+        containing user profile details and creates a new profile. If the
+        user already has a profile, it raises a ProfileAlreadyExistsError.
+
+        Note:
+            The `data` dictionary must contain the following keys:
+
+                - firstName
+                - surname
+                - mobile
+                - gender
+                - maritalStatus
+                - country
+                - state
+                - postcode
+                - signature
+                - identificationDocuments
+
+            If any of these keys are missing, `handle_profile_json` will raise an error.
+
+        Parameters:
+            data (dict): A dictionary containing the user profile details.
+            request (HttpRequest): The request object, containing user info and HTTP method.
+
+        Raises:
+            ProfileAlreadyExistsError: If a profile for the user already exists.
+
+        Returns:
+            Profile: The newly created user profile object.
+        """
+        user = request.user
+        if Profile.objects.filter(user=user).exists():
+            raise ProfileAlreadyExistsError("Profile for this user already exists")
+                
         profile = Profile.objects.create(user=request.user,
     
-                        first_name=data.get("firstName"),
-                        surname=data.get("surname"),
-                        mobile=data.get("mobile"),
-                        gender=data.get("gender"),
-                        maritus_status=data.get("maritusStatus"),
-                        country=data.get("country"),
-                        state=data.get("state"),
-                        postcode= data.get("postcode"),
-                        signature=data.get("signature"),
-                        identification_documents=data.get("identificationDocuments")
+            first_name=data.get("firstName"),
+            surname=data.get("surname"),
+            mobile=data.get("mobile"),
+            gender=data.get("gender"),
+            maritus_status=data.get("maritusStatus"),
+            country=data.get("country"),
+            state=data.get("state"),
+            postcode= data.get("postcode"),
+            signature=data.get("signature"),
+            identification_documents=data.get("identificationDocuments")
                         
-                )
+        )
+        return profile
 
-    except IntegrityError as e:
-        error_msg = f"A database error occurred. Possible duplicate or invalid data: {str(e)}"
-        return api_response(error=error_msg, status_code=409, data=data)
-
-    except Exception as e:
-        error_msg = f"Something went wrong on the server: Additional info {e}"
-        return api_response(error=error_msg, status_code=500, data=data)
-    return api_response(status_code=201, message="Successfully saved the data", success=True, data=profile_to_dict(profile))        
+    return handle_profile_json(request, create_profile, profile_to_dict)  
        
    
-      
+
+@csrf_protect
+@login_required
+def update_profile_details(request):
+    """
+    Handle a POST request from the frontend to update the user profile details.
+
+    This view is intended to be called via JavaScript (e.g. `fetch`) and delegates
+    the updation of the profile to a helper function. Since the data is being sent
+    as a POST It ensures that the request is authenticated and protected against 
+    CSRF attacks.
+
+    The actual logic for updating the profile is handled by the `update_profile` 
+    closure, and serialisation is performed using `profile_to_dict`.
+
+    Only users who already have a profile can update their profile. if the user
+    doesn't have a profile then fetch API will send the request to `save_profile_details`
+    which in turn will create a new profile.
+
+    Returns:
+        JsonResponse: A JSON response containing the saved profile data or an error.
+    """
+    def update_profile(data: dict, request: HttpRequest):
+        """
+        Updates an existing user profile with modified fields.
+
+        This function is called by `handle_profile_json` and receives a dictionary
+        containing only the fields that have changed on the frontend. It updates 
+        only those fields in the corresponding user profile.
+
+        Note:
+            The `data` dictionary includes only the modified fields, which ensures that
+            only those fields are updated in the database.
+
+        Parameters:
+            data (dict): A dictionary containing the updated user profile fields.
+            request (HttpRequest): The HTTP request object, containing user information.
+
+        Raises:
+            UserDoesNotExistError: If no profile exists for the current user.
+
+        Returns:
+            Profile: The updated user profile instance.
+        """
+        
+        profile = Profile.get_by_user(request.user)
+        if profile == None:
+            raise UserDoesNotExistError("The user doesn't exist")
+
+        profile = update_changed_profile_fields(data, profile)
+        return profile
+    
+    return handle_profile_json(request, update_profile, profile_to_dict, update=True)  
+    
+
+
+@login_required
+def get_profile_details(request):
+    """
+    Handles a GET request from the frontend to retrieve the user's profile details.
+
+    This view is intended to be called via JavaScript (e.g. `fetch`) and returns the
+    user's profile data as a JSON response. Since this is a read-only GET request, a
+    CSRF token or decorator is not required.
+
+    Returns:
+        JsonResponse: A JSON response containing the user's profile data or an error
+                    message if retrieval fails.
+    """
+
+    if request.method != "GET":
+        return api_response(error="Only GET method is allowed", status_code=405)
+    
+    profile = Profile.get_by_user(request.user)
+
+    if profile:
+        updated_data = profile_to_dict(profile)
+
+        return api_response(status_code=200, message="Successfully retrieved the data", success=True, data=updated_data)        
+    
+    return api_response(status_code=400, message="Failed to retrieve data", success=True, data={})    
+
+ 
+

--- a/account/views_helper.py
+++ b/account/views_helper.py
@@ -1,25 +1,34 @@
+import json
+
 from typing import Optional, Any
 from django.http import JsonResponse
+from django.db import IntegrityError
+from django.http import HttpRequest
 
+from .models import Profile
+from .utils.errors import ProfileAlreadyExistsError, UserDoesNotExistError
 
 
 def api_response( success: bool = False, 
                   message: str = '',
                   error: str = '', 
                   status_code: int = 200, 
+                  update : bool = False,
                   data: Optional[Any] = None) -> JsonResponse:
     
     return JsonResponse({
         'SUCCESS': success,
         'MESSAGE': message,
         'ERROR': error,
-        'DATA': data or {}
+        'DATA': data or {},
+        'UPDATE': update
+
     }, status=status_code)
 
 
 
 def profile_to_dict(profile):
-
+    
     return {
         "firstName": profile.first_name,
         "surname": profile.surname,
@@ -31,4 +40,142 @@ def profile_to_dict(profile):
         "postcode": profile.postcode,
         "identificationDocuments": profile.identification_documents,
         "signature": profile.signature,
+       
+      
 }
+
+
+def handle_profile_json(request, func, extract_profile_data, update = False):
+    """
+    Handles a JSON-based POST request to create or update a user profile.
+
+    A helper function utility function that processes incoming JSON data from a POST request, validates
+    its structure, and delegates the creation or update logic to the provided `func`
+    callable. The response includes either a success message with the profile data
+    (serialised using `extract_profile_data`) or an appropriate error message.
+
+    Parameters:
+        request (HttpRequest): The HTTP request object, expected to contain JSON data in the body.
+        func (callable): A function that performs the creation or update of the profile.
+                        It should accept `data` (dict) and `request` as arguments and return a 
+                        profile object.
+        extract_profile_data (callable): A function used to serialise the profile object into a dictionary.
+        update (bool): A flag to indicate whether the operation is an update (default is False).
+
+    Returns:
+        JsonResponse: A standardised JSON response indicating success or failure,
+                    including a message, status code, and optionally the serialised data.
+
+    Raises:
+        Returns HTTP 400/409/500 responses depending on the exception raised:
+            - JSONDecodeError: If the request body cannot be parsed.
+            - ValueError: If the data is not a dictionary.
+            - IntegrityError: If a database constraint is violated.
+            - ProfileAlreadyExistsError: If attempting to create a duplicate profile.
+            - UserDoesNotExistError: If no profile exists for the user.
+            - Exception: For any other unexpected errors.
+    """
+
+    if not isinstance(request, HttpRequest):
+        return api_response(error="Something went wrong, please try again later", status_code=500)
+    
+    if request.method != "POST":
+        return api_response(error="Only POST method is allowed", status_code=405)
+  
+    try:
+        data = json.loads(request.body.decode('utf-8'))
+     
+        if not isinstance(data, dict):
+            raise ValueError(f"The data is not an instance of dictionary. Expected the data object to be type dictionary but got type {type(data)}")
+        
+        profile = func(data, request)
+       
+    except json.JSONDecodeError as e:
+        error_msg = f'Invalid JSON data: {str(e)}'
+        return api_response(error=error_msg, status_code=400)
+    except ValueError as e:
+        return api_response(error=str(e), status_code=400)       
+    except IntegrityError as e:
+        error_msg = f"A database error occurred. Possible duplicate or invalid data: {str(e)}"
+        return api_response(error=error_msg, status_code=409, data=data)
+    except ProfileAlreadyExistsError as e:
+        return api_response(error=str(e), status_code=409)
+    except UserDoesNotExistError as e:
+        return api_response(error=str(e), status_code=409)
+    except Exception as e:
+        error_msg = f"Something went wrong on the server: Additional info {e}"
+        return api_response(error=error_msg, status_code=500, data=data)
+    
+    return api_response(status_code=201, 
+                        message="Successfully saved the data",
+                        success=True, 
+                        update=update,
+                         data=extract_profile_data(profile)
+                         )        
+       
+
+
+def update_changed_profile_fields(data: dict, profile: Profile):
+    """
+    Updates only the modified fields of a user profile based on frontend input.
+
+    This function is used in conjunction with `update_profile_details` API function.
+    It receives a dictionary containing only the fields that have changed on the frontend
+    and updates the corresponding fields in the `Profile` model instance.
+
+    The function first performs a mapping between frontend field names (typically in camelCase)
+    and model field names (snake_case) to ensure that only the changed values are persisted
+    to the database.
+
+    Note:
+        The `data` dictionary is expected to follow this structure:
+
+            {
+                "firstName": {
+                    "changed": "New value",
+                    "current": "Previous value"
+                },
+                ...
+            }
+
+        Only the `changed` value is written to the model.
+
+    Parameters:
+        data (dict): A dictionary containing the fields that have been modified,
+                    along with their old and new values.
+        profile (Profile): The profile instance to be updated.
+
+    Returns:
+        Profile: The updated profile instance (saved if any changes were made).
+    """
+
+    profile_translation_mapping =  {
+        "firstName": "first_name",
+        "surname": "surname",
+        "mobile": "mobile",
+        "gender": "gender",
+        "maritusStatus": "maritus_status",
+        "country": "country",
+        "state": "state",
+        "postcode": "postcode",
+        "identificationDocuments": "identification_documents",
+        "signature": "signature",
+    }
+
+    is_changed = False
+
+    for field in data:
+        
+        updated_field = data[field].get("changed")
+        profile_field = profile_translation_mapping.get(field)
+
+        if hasattr(profile, profile_field):
+            if not is_changed:
+                is_changed = True
+            setattr(profile, profile_field, updated_field)
+    
+    if is_changed:
+        profile.save()
+    
+    return profile
+

--- a/authentication/context_processors.py
+++ b/authentication/context_processors.py
@@ -1,17 +1,21 @@
+from account.models import Profile
 
 def show_pin(request):
-    pin         = None
-    joined_date = None
-    email       = None
+    pin                 = None
+    joined_date         = None
+    email               = None
+    is_profile_created  = False
 
     if request.user.is_authenticated:
-        pin         = request.user.pin 
-        joined_date = request.user.joined_on
-        email       = request.user.email
+        pin                = request.user.pin 
+        joined_date        = request.user.joined_on
+        email              = request.user.email
+        is_profile_created = Profile.objects.filter(user=request.user).exists()
        
     return {
         "PIN":pin,
         "JOINED_DATE": joined_date,
         "EMAIL": email,
+        "IS_PROFILE_CREATED": is_profile_created
 
     }

--- a/home/views.py
+++ b/home/views.py
@@ -12,6 +12,6 @@ def home(request):
     profile_form = ProfileForm()
 
     context = {
-        "profile_form": profile_form
+        "profile_form": profile_form,
     }
     return render(request, "index.html", context=context)

--- a/static/js/db.js
+++ b/static/js/db.js
@@ -22,21 +22,10 @@ export function getLocalStorage(key) {
 
 
 
-export function removeFromLocalStorage(key, id) {
-    const items = getLocalStorage(key);
-
-    if (items && Array.isArray(items)) {
-        const newItems = filterItemsById(items, id);
-
-        if (newItems.length !== items.length) { 
-            setLocalStorage(key, newItems);
-        } else {
-            console.log(`Item with id ${id} was not found in ${key}.`);
-        }
-
-    } else {
-        console.log(`Attempted to remove item with id ${id} but the key "${key}" does not exist or is not an array.`);
-    }
+export function removeFromLocalStorage(key) {
+  try {
+    localStorage.removeItem(key);
+  } catch (e) {
+    console.warn(`Could not remove localStorage key ${key}:`, e);
+  }
 }
-
-

--- a/static/js/fetch.js
+++ b/static/js/fetch.js
@@ -4,15 +4,18 @@ export default async function fetchData({ url, csrfToken = null, body = null, me
     try {
 
         const allowedMethods = ["POST", "GET"];
+
         
         if (!allowedMethods.includes(method)) {
             throw new Error(`Invalid method: ${method}. Allowed methods are ${allowedMethods.join(", ")}`);
         };
 
-        if (method === "POST" && typeof body !== "object" || body === null) {
-            throw new Error(`Body must be a non-null object for POST requests, received: ${typeof body}`);
-        };
-      
+     
+        if (method === "POST" && (typeof body !== "object")) {
+               throw new Error(`Body must be a non-null object for POST requests, received: ${typeof body}`);
+        }
+
+
         const headers = {
             "Content-Type": "application/json",
         };
@@ -26,7 +29,7 @@ export default async function fetchData({ url, csrfToken = null, body = null, me
             headers,
         };
 
-
+    
          if (method === "POST" && body) {
             options.body = JSON.stringify(body);
         };

--- a/static/js/pin.js
+++ b/static/js/pin.js
@@ -51,7 +51,7 @@ export function handlePinShowage(e, wallet) {
    if (id !== ADD_FUNDS_ID && id !== ADD_NEW_CARD && id !== TRANSFER_FUNDS && id !== REMOVE_CARD) {
         return false;
    }
-    alert(id);
+
    if (!PIN_ENTERED) {
         showPinErrorMsg('', false);
         pinElement.classList.add("show");

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -60,6 +60,34 @@ import { handleSelectAccountTransferElement,
         handleCardTransferAmountFormButtonClick 
         } from "./sideBarTransfer-funds.js";
 import { handlePageRefresh } from "./showOnRefresh.js";
+import { getLocalStorage, removeFromLocalStorage, setLocalStorage } from "./db.js";
+import { config } from "./config.js";
+
+
+// In most web browsers like Chrome or Firefox, data stored in localStorage persists 
+// across sessions, which is useful. However, if the application's data schema or logic 
+// changes (e.g., after an update), the cached localStorage data may become outdated or 
+// incompatible. Since browsers don’t automatically clear or update localStorage on app updates, 
+// stale data may remain until the user manually clears it or performs a hard refresh.
+// 
+// To handle this, the app stores a version number in localStorage. When the app version changes, 
+// it clears relevant localStorage keys and updates the stored version number.
+// This forces the app to start fresh with the latest data, preventing inconsistencies caused 
+// by old cached values.
+const APP_VERSION     = '3.0.1'; 
+const CURRENT_VERSION = getLocalStorage('app_version');
+
+if (CURRENT_VERSION !== APP_VERSION) {
+  console.warn(`App version changed from ${CURRENT_VERSION || 'none'} to ${APP_VERSION}. Clearing localStorage.`);
+  
+  [config.PROFILE_KEY, config.WALLET_STORAGE_KEY, config.NOTIFICATION_KEY].forEach((key) => {
+        removeFromLocalStorage(key);
+  })
+ 
+  setLocalStorage('app_version', APP_VERSION);
+}
+
+
 
 // elements
 const dashboardElement = document.getElementById("virtualbank-dashboard");

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -283,7 +283,7 @@ export function compareTwoObjects(object1, object2) {
     const keys2 = Object.keys(object2);
 
     if (keys1.length !== keys2.length) {
-        return { areEqual: false, changes: null };
+        return { areEqual: false, changes: null, keysObject1: keys1.length, keysObject2: keys2.length };
     }
 
     const changes = {};
@@ -293,7 +293,7 @@ export function compareTwoObjects(object1, object2) {
         const value2 = object2[key]?.trim?.() || object2[key];
 
         if (value1 !== value2) {
-            changes[key] = { previous: value1, current: value2 };
+            changes[key] = { changed: value1, current: value2 };
         }
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -27,8 +27,9 @@
 
     </main>
 
-    <script src="{% static '/js/script.js' %}" type="module" defer></script>
+   
     <script src="{% static '/js/profile.js' %}" type="module" defer></script>
+     <script src="{% static '/js/script.js' %}" type="module" defer></script>
 
 
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>

--- a/templates/partials/main/add_account_info.html
+++ b/templates/partials/main/add_account_info.html
@@ -40,7 +40,9 @@
 
             <div class="footer center flex-direction-column">
                 <small class="green">Logged in</small>
-                <button type="button" id="profileBtn" class="button margin-top-sm"></button>
+             
+                <button type="button" id="profileBtn" class="button margin-top-sm">Add Profile</button>
+                
             </div>
         </div>
 

--- a/templates/partials/main/add_account_info_form.html
+++ b/templates/partials/main/add_account_info_form.html
@@ -1,5 +1,5 @@
 
-<form action="{% url 'save_profile_details' %}" method="post" id="profile-form">
+<form action="#" method="post" id="profile-form">
 
     {% csrf_token %}
 


### PR DESCRIPTION
…, **create**, and **update** the user profile via `fetch`.

1. When the application is first loaded after the user logs in, the script checks if profile data exists in `localStorage`.
   - If it doesn't, a fetch request is made to the backend.
   - Assuming the user has an existing profile, the data is returned, cached in `localStorage`, and used to update the UI.

   This ensures that on subsequent page loads, profile data is restored from the cache rather than refetched, reducing unnecessary API/database calls.

2. The user can also **create** or **update** their profile via fetch *without requiring a page refresh*. Only changed fields are sent when updating.

Updated frontend and backend to support profile creation, updating, and retrieve via a fetch API

**Backend:**

* `views.py`:

  * Added `handle_profile_json` function to process JSON profile data with error handling for various exceptions.
  * Added custom exceptions `ProfileAlreadyExistsError` and `UserDoesNotExistError` to improve error clarity.

* `models.py` / Helpers:

  * Added helper function `update_changed_profile_fields` to update only modified fields from frontend.

* API endpoints:

  * `/profile/get/` for retrieving user profile data.
  * `/profile/update/` for updating only changed fields.

**Frontend:**

* `profile.js`:

  * Implemented `handleProfileForm` to route form submissions to create or update API calls.
  * Added `handleProfileData` to prepare and send profile data, comparing with cached data to send only changed fields when updating.
  * Added `handleProfileFetchResponse` to process API responses, update cache, show alerts, and manage form UI.

* Caching:

  * Used `localStorage` to cache profile data and reduce redundant backend calls.
  * Added `APP_VERSION` check to clear cache and force reload on app updates to avoid stale data issues.

1. Did a hard refresh to clear the cache
1. User logs in.
2. A fetch request pulls profile data from the backend and stores it in the local cache.
3. User clicks **Edit Profile** to load their saved data into the form.
4. User updates their profile and clicks **Edit** to save the changes.
5. The updated data is sent to the backend and saved.
6. User receives a success alert confirming the data has been saved.
7. A notification is sent to confirm the update.
8. User clicks **Edit Profile** again and sees the newly updated data populated in the form.
9. User can verify the changes in the admin backend.

---

1. Did a hard refresh to clear the cache
1. User logs in.
2. User fills in their profile details in the form.
3. User clicks **Save** to submit the data.
4. User receives a success alert confirming the data has been saved.
5. User clicks **Edit Profile** to load and view the newly saved data.
6. User can verify the data in the admin backend.

**Note**
The logout link is not working in the navigation since the links are not activated. To logout one has to manually add "/logout" to the url

There is currently a flaw in how the application handles profile data persistence via `localStorage`. This results in an unintended exposure of stale or incorrect user information when switching accounts on the same device.

When a user logs in, the application checks if profile data exists in `localStorage`. If it does, it assumes that data is valid for the current session and enables the **Fetch profile information** button. Clicking the button then loads the cached data into the form without verifying ownership.

1. **User A (e.g. John Smith)** logs in, fills in their profile on the same browser, and the data is saved both to the backend and `localStorage`.
2. User A logs out.
3. **User B (e.g. Jenny Smith)** logs in using the same browser.
4. The application detects the existing profile JSON in `localStorage`, assumes it's valid and belongs to User B when it in facts belongs to User A (e.g Joh Smith).
5. The **Fetch profile information** button appears. When clicked, it loads **John's** data into the form, even though **Jenny** is logged in.

This results in profile fields being pre-populated with another user's data, which can lead to confusion and potential data exposure on shared machines.

> ⚠️ Despite this frontend flaw, **updates still modify the correct user’s profile**.

This is because the backend does **not** trust or use user-identifying fields (e.g. `user_id`, `email`) sent from the frontend. Instead:

* It determines the authenticated user from the request context (via session cookies or access tokens).
* It then fetches the correct user `Profile` instance for that user and applies any updates.
* The frontend data is treated purely as form input  not as user identity.

Therefore, even if User B sees User A’s details in the form, any changes submitted are written to **User B’s** profile on the backend.

In a future commit, this flaw will be addressed by:

* Scoping `localStorage` profile data to the specific user (e.g. using a namespaced key tied to user ID or username).
* Verifying that stored profile data matches the currently authenticated user before displaying or using it.